### PR TITLE
Return json objects instead of strings

### DIFF
--- a/FriendsAndPlaces/Functions/CoordinatesFunction.cs
+++ b/FriendsAndPlaces/Functions/CoordinatesFunction.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
 
 namespace FriendsAndPlaces.Functions
 {
@@ -55,7 +54,7 @@ namespace FriendsAndPlaces.Functions
                 return new NotFoundResult();
             }
 
-            return new OkObjectResult(JsonConvert.SerializeObject(coordinatesResponse));
+            return new OkObjectResult(coordinatesResponse);
         }
     }
 }

--- a/FriendsAndPlaces/Functions/LocationsFunction.cs
+++ b/FriendsAndPlaces/Functions/LocationsFunction.cs
@@ -96,7 +96,7 @@ namespace FriendsAndPlaces.Functions
             // Check if all parameters are present
             if (string.IsNullOrWhiteSpace(loginName) ||
                 string.IsNullOrWhiteSpace(sessionId) ||
-                string.IsNullOrWhiteSpace(userId) )
+                string.IsNullOrWhiteSpace(userId))
             {
                 return new BadRequestResult();
             }
@@ -126,7 +126,7 @@ namespace FriendsAndPlaces.Functions
             };
 
             //Response with Coordinates
-            return new OkObjectResult(JsonConvert.SerializeObject(locationResponse));
+            return new OkObjectResult(locationResponse);
         }
     }
 }

--- a/FriendsAndPlaces/Functions/LoginFunction.cs
+++ b/FriendsAndPlaces/Functions/LoginFunction.cs
@@ -86,7 +86,7 @@ namespace FriendsAndPlaces.Functions
                 SessionId = sessionId.ToString()
             };
 
-            return new OkObjectResult(JsonConvert.SerializeObject(loginResponse));
+            return new OkObjectResult(loginResponse);
         }
     }
 }

--- a/FriendsAndPlaces/Functions/LogoutFunction.cs
+++ b/FriendsAndPlaces/Functions/LogoutFunction.cs
@@ -1,15 +1,14 @@
-using System.IO;
 using FriendsAndPlaces.Helpers.Database;
-using FriendsAndPlaces.Models.Login;
+using FriendsAndPlaces.Models.Logout;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using FriendsAndPlaces.Models.Logout;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace FriendsAndPlaces.Functions
 {
@@ -45,7 +44,7 @@ namespace FriendsAndPlaces.Functions
                 return new UnsupportedMediaTypeResult();
             }
 
-            string requestBody =  new StreamReader(req.Body).ReadToEndAsync().Result;
+            string requestBody = new StreamReader(req.Body).ReadToEndAsync().Result;
             var logoutRequest = JsonConvert.DeserializeObject<LogoutRequest>(requestBody);
 
 
@@ -55,10 +54,10 @@ namespace FriendsAndPlaces.Functions
             {
                 return new BadRequestResult();
             }
-            
+
             // Delete session from database
 
-            
+
 
             _databaseManager.DeleteSession(logoutRequest.LoginName, logoutRequest.SessionId);
 
@@ -71,7 +70,7 @@ namespace FriendsAndPlaces.Functions
                 ergebnis = true
             };
 
-            return new OkObjectResult(JsonConvert.SerializeObject(logoutResponse));
+            return new OkObjectResult(logoutResponse);
         }
     }
 }

--- a/FriendsAndPlaces/Functions/UsersFunction.cs
+++ b/FriendsAndPlaces/Functions/UsersFunction.cs
@@ -148,7 +148,7 @@ namespace FriendsAndPlaces.Functions
                 });
             }
 
-            return new OkObjectResult(JsonConvert.SerializeObject(publicUsers));
+            return new OkObjectResult(publicUsers);
         }
     }
 }


### PR DESCRIPTION
Custom Settings (JsonProperty Name) wird trotzdem ausgewertet, da NewtonsoftJson der Standard für Serializations bei Azure Functions ist.

Closes #37 

@twansing wenn der PR durch ist, kann die Response direkt als Objekt geparst werden 👍 